### PR TITLE
SIM: modify id and offset for Ecal and Hcal

### DIFF
--- a/Detector/DetCEPCv4/compact/SEcal05_siw_ECRing_01.xml
+++ b/Detector/DetCEPCv4/compact/SEcal05_siw_ECRing_01.xml
@@ -51,7 +51,8 @@
 
   <readouts>
     <readout name="EcalEndcapRingCollection">
-      <segmentation type="CartesianGridXY" grid_size_x="Ecal_cells_size" grid_size_y="Ecal_cells_size"/>
+      <segmentation type="CartesianGridXY" grid_size_x="Ecal_cells_size" grid_size_y="Ecal_cells_size"
+		    offset_x="-0.5*Ecal_ECRing_Siplate_Size+0.5*Ecal_cells_size" offset_y="-0.5*Ecal_ECRing_Siplate_Size+0.5*Ecal_cells_size"/>
       <id>system:5,module:3,stave:4,tower:3,layer:6,x:32:-16,y:-16</id>
     </readout>
   </readouts>

--- a/Detector/DetCEPCv4/compact/SHcalRpc01_Barrel_01.xml
+++ b/Detector/DetCEPCv4/compact/SHcalRpc01_Barrel_01.xml
@@ -33,8 +33,8 @@
 
   <readouts>
     <readout name="HcalBarrelCollection">
-      <segmentation type="CartesianGridYZ" grid_size_y="Hcal_cells_size" grid_size_z="Hcal_cells_size"/>
-      <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,y:32:-16,z:-16</id>
+      <segmentation type="TiledLayerGridXY" grid_size_x="Hcal_cells_size" grid_size_y="Hcal_cells_size"/>
+      <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
     </readout>
   </readouts>
 

--- a/Detector/DetCEPCv4/compact/SHcalRpc01_EndcapRing_01.xml
+++ b/Detector/DetCEPCv4/compact/SHcalRpc01_EndcapRing_01.xml
@@ -10,7 +10,7 @@
                    dz="HcalEndcapRing_max_z + 2.0*env_safety"/>
             <shape type="PolyhedraRegular" numsides="Hcal_ring_inner_symmetry" rmin="HcalEndcapRing_inner_radius - env_safety"
                    rmax="HcalEndcapRing_outer_radius*cos(pi/Hcal_ring_outer_symmetry) + env_safety" dz="2.0*HcalEndcapRing_max_z + env_safety" material="Air"/>
-            <rotation x="0" y="0" z="90*deg-180*deg/Hcal_ring_inner_symmetry"/>
+            <rotation x="0" y="0" z="-180*deg/Hcal_ring_inner_symmetry"/>
           </shape>
           <shape type="Box" dx="HcalEndcapRing_outer_radius + 2.0*env_safety" dy="HcalEndcapRing_outer_radius + 2.0*env_safety"
                  dz="HcalEndcapRing_min_z - env_safety"/>
@@ -32,8 +32,8 @@
 
   <readouts>
     <readout name="HcalEndcapRingCollection">
-      <segmentation type="CartesianGridXY" grid_size_x="Hcal_cells_size" grid_size_y="Hcal_cells_size"/>
-      <id>system:5,module:3,stave:4,tower:3,layer:6,x:32:-16,y:-16</id>
+      <segmentation type="CartesianGridXY" grid_size_x="Hcal_cells_size" grid_size_y="Hcal_cells_size" offset_x="Hcal_cells_size/2.0" offset_y="Hcal_cells_size/2.0"/>
+      <id>system:5,module:3,stave:4,tower:3,layer:6,y:32:-16,x:-16</id>
     </readout>
   </readouts>
   

--- a/Detector/DetCEPCv4/compact/SHcalRpc01_Endcaps_01.xml
+++ b/Detector/DetCEPCv4/compact/SHcalRpc01_Endcaps_01.xml
@@ -31,7 +31,7 @@
   <readouts>
     <readout name="HcalEndcapsCollection">
       <segmentation type="CartesianGridXY" grid_size_x="Hcal_cells_size" grid_size_y="Hcal_cells_size" offset_x="Hcal_cells_size/2.0" offset_y="Hcal_cells_size/2.0" />
-      <id>system:5,module:3,stave:3,tower:5,layer:6,x:32:-16,y:-16</id>
+      <id>system:5,module:3,stave:3,tower:5,layer:6,y:32:-16,x:-16</id>
     </readout>
   </readouts>
   

--- a/Detector/DetCEPCv4/compact/ecal_defs.xml
+++ b/Detector/DetCEPCv4/compact/ecal_defs.xml
@@ -55,7 +55,8 @@
   <constant name="Ecal_Slab_Plug_length" value="0*mm"/>
   
   <!-- needed only for ecal ring driver... -->
-  <constant name="Ecal_cells_size" value="10.2105*mm"/>
+  <constant name="Ecal_ECRing_Siplate_Size" value="Ecal_endcap_center_box_size - 2*Ecal_EC_Ring_gap - 2*Ecal_lateral_face_thickness"/>
+  <constant name="Ecal_cells_size" value="Ecal_ECRing_Siplate_Size/76."/>
   <constant name="Ecal_Sc_reflector_thickness" value="0.057*mm"/>
   <constant name="Ecal_Sc_thickness" value="2.0*mm"/>
   <constant name="Ecal_Slab_Sc_PCB_thickness" value="0.8*mm"/>

--- a/Detector/DetCEPCv4/src/calorimeter/SHcalRpc01_EndcapRing.cpp
+++ b/Detector/DetCEPCv4/src/calorimeter/SHcalRpc01_EndcapRing.cpp
@@ -197,7 +197,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
   
   // chamber placements
   for(int stave_id = 1; stave_id <= 4; stave_id++){
-    double angle = pi/2.*(stave_id-1);
+    double angle = -pi/2.*(stave_id-1);
     RotationZYX lrot(angle,0,0);
     for (int layer_id = 1; layer_id <= number_of_chambers; layer_id++){
       double Zoff = -pDz + (layer_id-1)*layerThickness + Hcal_radiator_thickness + Hcal_chamber_thickness/2.;
@@ -217,28 +217,30 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	cout << "Hcal_EndcapRing:  inner_thickness= " << inner_thickness << endl;
 	cout << "Hcal_EndcapRing:  outer_thickness= " << thickness_sum << endl;
       }
-      LayeredCalorimeterData::Layer caloLayer ;
-      caloLayer.cellSize0 = cell_sizeX;
-      caloLayer.cellSize1 = cell_sizeY;
-      caloLayer.inner_nRadiationLengths   = nRadiationLengthsInside;
-      caloLayer.inner_nInteractionLengths = nInteractionLengthsInside;
-      caloLayer.inner_thickness           = inner_thickness;
-      caloLayer.sensitive_thickness       = sensitive_thickness;
-      caloLayer.outer_nRadiationLengths   = nRadiationLengths;
-      caloLayer.outer_nInteractionLengths = nInteractionLengths;
-      caloLayer.outer_thickness           = thickness_sum;
+      if(stave_id==1){//only one needed, according to wenxingfang's
+	LayeredCalorimeterData::Layer caloLayer ;
+	caloLayer.cellSize0 = cell_sizeX;
+	caloLayer.cellSize1 = cell_sizeY;
+	caloLayer.inner_nRadiationLengths   = nRadiationLengthsInside;
+	caloLayer.inner_nInteractionLengths = nInteractionLengthsInside;
+	caloLayer.inner_thickness           = inner_thickness;
+	caloLayer.sensitive_thickness       = sensitive_thickness;
+	caloLayer.outer_nRadiationLengths   = nRadiationLengths;
+	caloLayer.outer_nInteractionLengths = nInteractionLengths;
+	caloLayer.outer_thickness           = thickness_sum;
+	
+	caloLayer.distance = start_z + (layer_id-1)*layerThickness;
+	caloLayer.absorberThickness = Hcal_radiator_thickness ;
       
-      caloLayer.distance = start_z + (layer_id-1)*layerThickness;
-      caloLayer.absorberThickness = Hcal_radiator_thickness ;
-      
-      caloData->layers.push_back( caloLayer ) ;
+	caloData->layers.push_back( caloLayer ) ;
+      }
     }
   }
   
   // Placements
   double endcap_z_offset = start_z + pDz;
   for(int side = 0; side <= 1; side++){
-    int module_id = (side==0) ? 0 : 6;
+    int module_id = (side==0) ? 6 : 0;
     double this_module_z_offset = (side==0) ? endcap_z_offset : -endcap_z_offset;
     // use reflect volume for z<0, therefore, same rotation
     // segmentation violation happen if EndCapRingLogical.reflect(), back to rotate Y

--- a/Detector/DetCEPCv4/src/calorimeter/SHcalRpc01_Endcaps.cpp
+++ b/Detector/DetCEPCv4/src/calorimeter/SHcalRpc01_Endcaps.cpp
@@ -205,7 +205,7 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
   if(possible_number_of_chambers < number_of_chambers) number_of_chambers = possible_number_of_chambers;
   // chamber placements
   for(int stave_id = 1; stave_id <= 4; stave_id++){
-    double angle = pi/2.*(stave_id-1);
+    double angle = -pi/2.*(stave_id-1);
     //RotationZ lrotz(angle);
     RotationZYX lrot(angle,0,0);
     for (int layer_id = 1; layer_id <= number_of_chambers; layer_id++){
@@ -226,28 +226,30 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 	cout << "Hcal_Endcap:  inner_thickness= " << inner_thickness << endl;
 	cout << "Hcal_Endcap:  outer_thickness= " << thickness_sum << endl;
       }
-      LayeredCalorimeterData::Layer caloLayer ;
-      caloLayer.cellSize0 = cell_sizeX;
-      caloLayer.cellSize1 = cell_sizeY;
-      caloLayer.inner_nRadiationLengths = nRadiationLengthsInside;
-      caloLayer.inner_nInteractionLengths = nInteractionLengthsInside;
-      caloLayer.inner_thickness = inner_thickness;
-      caloLayer.sensitive_thickness = sensitive_thickness;
-      caloLayer.outer_nRadiationLengths = nRadiationLengths;
-      caloLayer.outer_nInteractionLengths = nInteractionLengths;
-      caloLayer.outer_thickness = thickness_sum;
-      
-      caloLayer.distance = Hcal_start_z + (layer_id-1)*layerThickness;
-      caloLayer.absorberThickness = Hcal_radiator_thickness ;
-      
-      caloData->layers.push_back( caloLayer ) ;
+      if(stave_id==1){// only for one stave is good. by wenxingfang 
+	LayeredCalorimeterData::Layer caloLayer ;
+	caloLayer.cellSize0 = cell_sizeX;
+	caloLayer.cellSize1 = cell_sizeY;
+	caloLayer.inner_nRadiationLengths = nRadiationLengthsInside;
+	caloLayer.inner_nInteractionLengths = nInteractionLengthsInside;
+	caloLayer.inner_thickness = inner_thickness;
+	caloLayer.sensitive_thickness = sensitive_thickness;
+	caloLayer.outer_nRadiationLengths = nRadiationLengths;
+	caloLayer.outer_nInteractionLengths = nInteractionLengths;
+	caloLayer.outer_thickness = thickness_sum;
+	
+	caloLayer.distance = Hcal_start_z + (layer_id-1)*layerThickness;
+	caloLayer.absorberThickness = Hcal_radiator_thickness ;
+	
+	caloData->layers.push_back( caloLayer ) ;
+      }
     }
   }
   
   // Placements
   double endcap_z_offset = Hcal_start_z + Hcal_endcap_thickness/2.;
   for(int side = 0; side <= 1; side++){
-    int module_id = (side==0) ? 0 : 6;
+    int module_id = (side==0) ? 6 : 0;
     double this_module_z_offset = (side==0) ? endcap_z_offset : -endcap_z_offset;
     // use reflect volume for z<0, therefore, same rotation
     // segmentation violation happen if EndCapRingLogical.reflect(), back to rotate Y


### PR DESCRIPTION
* HcalBarrel has vary offset by layers, use TiledLayerGridXY now
* HcalEndcaps + HcalEndcapRing
  * x:y id is rotated in different quadrant, exchange them x<->y while saving data (set in segmentation `y:32:-16,x:-16`) to keep same as Mokka's